### PR TITLE
fix swipe glitches (sync reactions/media and allow swiping on reactions)

### DIFF
--- a/plugins/SwipeActions/src/com/github/razertexz/SwipeActions.kt
+++ b/plugins/SwipeActions/src/com/github/razertexz/SwipeActions.kt
@@ -1,29 +1,36 @@
 package com.github.razertexz
 
-import androidx.recyclerview.widget.RecyclerView
 import android.content.Context
 import android.util.AttributeSet
-
+import androidx.recyclerview.widget.RecyclerView
+import android.content.res.Resources
 import com.aliucord.annotations.AliucordPlugin
 import com.aliucord.entities.Plugin
-import com.aliucord.patcher.*
-import com.aliucord.utils.DimenUtils
-
+import com.aliucord.patcher.after
 import com.discord.databinding.WidgetChatListBinding
 import com.discord.panels.OverlappingPanelsLayout
 
 @AliucordPlugin(requiresRestart = true)
 class SwipeActions : Plugin() {
+
     override fun start(context: Context) {
-        val scrollingSlopPx = OverlappingPanelsLayout::class.java.getDeclaredField("scrollingSlopPx").apply { isAccessible = true }
-        val newScrollingSlopPx = DimenUtils.dpToPx(8.0f * 3.5f).toFloat()
+        val scrollingSlopField =
+            OverlappingPanelsLayout::class.java.getDeclaredField("scrollingSlopPx").also {
+                it.isAccessible = true
+            }
+        val newScrollingSlopPx = (Resources.getSystem().displayMetrics.density * 8.0f * 3.5f + 0.5f).toInt().toFloat()
+
         patcher.after<OverlappingPanelsLayout>("initialize", AttributeSet::class.java) {
-            scrollingSlopPx.set(this, newScrollingSlopPx)
+            scrollingSlopField.set(it.thisObject, newScrollingSlopPx)
         }
 
         val swipeHelper = SwipeHelper()
-        patcher.after<WidgetChatListBinding>(RecyclerView::class.java, RecyclerView::class.java) {
-            swipeHelper.attachToRecyclerView(it.args[0] as RecyclerView)
+
+        patcher.after<WidgetChatListBinding>(
+            RecyclerView::class.java,
+            RecyclerView::class.java
+        ) { param ->
+            swipeHelper.attachToRecyclerView(param.args[0] as RecyclerView)
         }
     }
 

--- a/plugins/SwipeActions/src/com/github/razertexz/SwipeHelper.kt
+++ b/plugins/SwipeActions/src/com/github/razertexz/SwipeHelper.kt
@@ -1,114 +1,157 @@
 package com.github.razertexz
 
-import androidx.recyclerview.widget.RecyclerView
-import android.view.View
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewConfiguration
-
-import com.discord.widgets.chat.list.entries.*
-import com.discord.widgets.chat.list.adapter.WidgetChatListAdapter
-import com.discord.widgets.chat.list.actions.WidgetChatListActions
+import androidx.recyclerview.widget.RecyclerView
 import com.discord.models.message.Message
 import com.discord.stores.StoreStream
-
-import kotlin.math.abs
-import kotlin.math.sign
+import com.discord.widgets.chat.list.actions.WidgetChatListActions
+import com.discord.widgets.chat.list.adapter.WidgetChatListAdapter
+import com.discord.widgets.chat.list.entries.*
 
 class SwipeHelper {
-    private lateinit var recyclerView: RecyclerView
 
-    private var touchSlop = 0.0f
-    private val swipeThreshold = 0.25f
+    private var recyclerView: RecyclerView? = null
+    private var touchSlop: Float = 0f
+    private val swipeThreshold: Float = 0.25f
 
     private val widgetChatListActions = WidgetChatListActions()
     private val storeChannels = StoreStream.getChannels()
-    private val myId = StoreStream.getUsers().me.id
+    private val myId: Long = StoreStream.getUsers().me.id
+
 
     private val onItemTouchListener = object : RecyclerView.OnItemTouchListener {
-        private lateinit var message: Message
-
+        private var initialX = 0f
+        private var initialY = 0f
+        private var message: Message? = null
         private var selectedView: View? = null
-        private var initialX = 0.0f
-        private var initialY = 0.0f
 
         override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
             when (e.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
                     val child = rv.findChildViewUnder(e.x, e.y) ?: return false
+                    val adapterPos = rv.getChildViewHolder(child).bindingAdapterPosition
+                    if (adapterPos == RecyclerView.NO_POSITION) return false
 
-                    val pos = rv.getChildViewHolder(child).adapterPosition.takeUnless { it == RecyclerView.NO_POSITION } ?: return false
-                    val entry = (rv.adapter as WidgetChatListAdapter).getData().getList()[pos]
-                    message = when (entry) {
-                        is MessageEntry -> entry.message
-                        is AttachmentEntry -> entry.message
-                        is StickerEntry -> entry.message
-                        is EmbedEntry -> entry.message
-                        else -> return false
-                    }
+                    val adapter = rv.adapter as? WidgetChatListAdapter ?: return false
+                    val entry = adapter.data.list.getOrNull(adapterPos) ?: return false
 
+                    message = getMessageFromEntry(entry) ?: return false
                     selectedView = child
                     initialX = e.x
                     initialY = e.y
+                    return false
                 }
-
-                MotionEvent.ACTION_MOVE -> {
-                    if (selectedView != null && rv.getScrollState() != RecyclerView.SCROLL_STATE_DRAGGING) {
-                        val diffX = abs(e.x - initialX)
-                        val diffY = abs(e.y - initialY)
-                        if (diffX > touchSlop && diffX > diffY * 3.0f) {
-                            rv.requestDisallowInterceptTouchEvent(true)
-                            return true
-                        }
-                    }
-                }
-
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                MotionEvent.ACTION_UP,
+                MotionEvent.ACTION_CANCEL -> {
                     selectedView = null
+                    return false
                 }
-            }
+                MotionEvent.ACTION_MOVE -> {
+                    val view = selectedView ?: return false
+                    if (rv.scrollState == RecyclerView.SCROLL_STATE_DRAGGING) return false
 
-            return false
+                    val diffX = Math.abs(e.x - initialX)
+                    val diffY = Math.abs(e.y - initialY)
+                    if (diffX > touchSlop && diffX > 3f * diffY) {
+                        rv.requestDisallowInterceptTouchEvent(true)
+                        return true
+                    }
+                    return false
+                }
+                else -> return false
+            }
         }
 
         override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
-            selectedView!!.let { view ->
-                when (e.actionMasked) {
-                    MotionEvent.ACTION_MOVE -> {
-                        view.translationX = e.x - initialX
-                    }
+            val view = selectedView ?: return
 
-                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                        if (abs(view.translationX) > view.width * swipeThreshold)
-                            onSwiped(view.translationX.sign)
-
-                        view.translationX = 0.0f
-                        selectedView = null
+            when (e.actionMasked) {
+                MotionEvent.ACTION_UP,
+                MotionEvent.ACTION_CANCEL -> {
+                    if (Math.abs(view.translationX) > view.width * swipeThreshold) {
+                        onSwiped(Math.signum(view.translationX))
                     }
+                    applyTranslationToMessageGroup(rv, 0f)
+                    selectedView = null
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val tx = e.x - initialX
+                    applyTranslationToMessageGroup(rv, tx)
                 }
             }
         }
 
         override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
 
+        private fun getMessageFromEntry(entry: Any): Message? {
+            return when (entry) {
+                is MessageEntry    -> entry.message
+                is AttachmentEntry -> entry.message
+                is StickerEntry    -> entry.message
+                is EmbedEntry      -> entry.message
+                is ReactionsEntry  -> entry.message
+                else               -> null
+            }
+        }
+
+        private fun applyTranslationToMessageGroup(rv: RecyclerView, tx: Float) {
+            val swipedMessageId = message?.id ?: return
+            val adapter = rv.adapter as? WidgetChatListAdapter ?: return
+
+            for (i in 0 until rv.childCount) {
+                val child = rv.getChildAt(i)
+                val holder = rv.getChildViewHolder(child)
+                val pos = holder.bindingAdapterPosition
+                
+                if (pos != RecyclerView.NO_POSITION && pos < adapter.itemCount) {
+                    val entry = adapter.data.list.getOrNull(pos) ?: continue
+                    val childMessage = getMessageFromEntry(entry)
+                    if (childMessage != null && childMessage.id == swipedMessageId) {
+                        child.translationX = tx
+                    }
+                }
+            }
+        }
+
         private fun onSwiped(dir: Float) {
-            if (dir == -1.0f)
-                WidgetChatListActions.`access$replyMessage`(widgetChatListActions, message, storeChannels.getChannel(message.channelId))
-            else if (message.author.id == myId)
-                WidgetChatListActions.`access$editMessage`(widgetChatListActions, message)
+            val msg = message ?: return
+            when {
+                dir == -1f -> {
+                    val replyMethod = WidgetChatListActions::class.java.getDeclaredMethod(
+                        "replyMessage",
+                        Message::class.java,
+                        com.discord.api.channel.Channel::class.java
+                    )
+                    replyMethod.isAccessible = true
+                    replyMethod.invoke(
+                        widgetChatListActions,
+                        msg,
+                        storeChannels.getChannel(msg.channelId)
+                    )
+                }
+                dir == 1f && msg.author.id == myId -> {
+                    val editMethod = WidgetChatListActions::class.java.getDeclaredMethod(
+                        "editMessage",
+                        Message::class.java
+                    )
+                    editMethod.isAccessible = true
+                    editMethod.invoke(widgetChatListActions, msg)
+                }
+            }
         }
     }
 
+
     fun attachToRecyclerView(rv: RecyclerView) {
-        if (this::recyclerView.isInitialized) {
-            if (recyclerView == rv)
-                return
-
-            recyclerView.removeOnItemTouchListener(onItemTouchListener)
+        val current = recyclerView
+        if (current != null) {
+            if (current == rv) return
+            current.removeOnItemTouchListener(onItemTouchListener)
         }
-
         touchSlop = ViewConfiguration.get(rv.context).scaledTouchSlop.toFloat()
-
         recyclerView = rv
-        recyclerView.addOnItemTouchListener(onItemTouchListener)
+        rv.addOnItemTouchListener(onItemTouchListener)
     }
 }


### PR DESCRIPTION
hey, i noticed a few visual issues with the swipe animations and put together some fixes for them:

- synced media and stickers: since images, gifs, and stickers are separate viewholders, they were getting left behind during swipes. now the code grabs everything matching the message id and translates them all together in sync.
- added swiping directly on reactions: you can now start the swipe gesture by dragging on the ReactionsEntry view itself instead of just the MessageEntry view.

let me know if this looks good to merge!